### PR TITLE
Two minor fixes

### DIFF
--- a/cudock
+++ b/cudock
@@ -31,7 +31,7 @@ generate()
 	ENV CUDA_VERSION ${cuda_version}
 	LABEL com.nvidia.cuda.version="${cuda_version}"
 	
-	RUN apt-get install -y --no-install-recommends --force-yes "cuda-toolkit-${cuda_version}" gpu-deployment-kit
+	RUN apt-get install -y --no-install-recommends --force-yes "cuda-toolkit-${cuda_version}"
 	
 	RUN echo "/usr/local/cuda/lib" >> /etc/ld.so.conf.d/cuda.conf && \\
 	    echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/cuda.conf && \\

--- a/nvidia-docker
+++ b/nvidia-docker
@@ -18,7 +18,8 @@ NV_LIBS_COMPUTE="cuda \
                  nvcuvid \
                  nvidia-compiler \
                  nvidia-encode \
-                 nvidia-ml"
+                 nvidia-ml \
+                 nvidia-fatbinaryloader"
 
 NV_DOCKER_ARGS=""
 


### PR DESCRIPTION
- The provisioning was broken, probably due to some changes in the NVIDIA packages.
- The testBandwidth sample would fail at runtime because a CUDA library was missing in the container.

See the commit messages for more details.
